### PR TITLE
Add Contract import

### DIFF
--- a/RealTimeData/LiveData-top.py
+++ b/RealTimeData/LiveData-top.py
@@ -3,6 +3,7 @@ from ibapi.client import *
 from ibapi.common import TickAttrib, TickerId
 from ibapi.wrapper import *
 from ibapi.ticktype import TickTypeEnum
+from ibapi.contract import Contract
 
 
 port = 7496

--- a/RealTimeData/MarketDepth.py
+++ b/RealTimeData/MarketDepth.py
@@ -2,6 +2,7 @@ from decimal import Decimal
 from ibapi.client import *
 from ibapi.common import TickerId
 from ibapi.wrapper import *
+from ibapi.contract import Contract
 
 port = 7496
 

--- a/RealTimeData/RealTimeBars.py
+++ b/RealTimeData/RealTimeBars.py
@@ -3,6 +3,7 @@ from ibapi.client import *
 from ibapi.common import TickerId
 from ibapi.wrapper import *
 from ibapi.tag_value import *
+from ibapi.contract import Contract
 from datetime import datetime
 
 port = 7496

--- a/RealTimeData/TickByTick.py
+++ b/RealTimeData/TickByTick.py
@@ -1,5 +1,6 @@
 from ibapi.client import *
 from ibapi.wrapper import *
+from ibapi.contract import Contract
 from datetime import datetime
 port = 7496
 


### PR DESCRIPTION
## Summary
- add `Contract` import to real-time data examples

## Testing
- `python -m py_compile RealTimeData/LiveData-top.py RealTimeData/MarketDepth.py RealTimeData/RealTimeBars.py RealTimeData/TickByTick.py`


------
https://chatgpt.com/codex/tasks/task_e_68507abca768832198640fc660ba8047